### PR TITLE
Improve Chrome launch and set binary path

### DIFF
--- a/facebook_ads_script.py
+++ b/facebook_ads_script.py
@@ -5,7 +5,7 @@ import time
 chrome_driver_path = r"C:\Users\ameli\Downloads\chromedriver-win64\chromedriver-win64\chromedriver.exe"
 
 # Path to Chrome executable - adjust if yours is different
-chrome_path = r'"C:\Program Files\Google\Chrome\Application\chrome.exe"'
+chrome_path = r"C:\Program Files\Google\Chrome\Application\chrome.exe"
 
 chatgpt = ChatGPTAutomation(chrome_path, chrome_driver_path)
 


### PR DESCRIPTION
## Summary
- launch Chrome using `subprocess.Popen` and wait briefly
- pass the Chrome binary to Selenium for remote debugging
- remove extra quotes from example Chrome path

## Testing
- `python -m py_compile chatgpt_selenium_automation/handler.py facebook_ads_script.py`


------
https://chatgpt.com/codex/tasks/task_e_6844b8876b8c8328afaf09e54e91c2b2