### PR TITLE
Use subprocess when launching Chrome

### DIFF
--- a/chatgpt_selenium_automation/handler.py
+++ b/chatgpt_selenium_automation/handler.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import socket
 import threading
 import time
@@ -70,8 +71,13 @@ class ChatGPTAutomation:
             provided url """
 
         def open_chrome():
-            chrome_cmd = f"{self.chrome_path} --remote-debugging-port={port} --user-data-dir=remote-profile {url}"
-            os.system(chrome_cmd)
+            chrome_cmd = [
+                self.chrome_path,
+                f"--remote-debugging-port={port}",
+                "--user-data-dir=remote-profile",
+                url,
+            ]
+            subprocess.Popen(chrome_cmd)
 
         chrome_thread = threading.Thread(target=open_chrome)
         chrome_thread.start()


### PR DESCRIPTION
## Summary
- start Chrome via `subprocess.Popen`
- expect plain `chrome_path` (spaces handled automatically)

## Testing
- `pytest -q`
- `flake8` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_6844edbcdf6c8328b7a3c8a50698555c