### PR TITLE
Fix driver location handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ ChatGPT Automation is a Python project that aims to automate interactions with O
  ```python
 from chatgpt_selenium_automation.handler import ChatGPTAutomation
 
-# Define the path where the chrome driver is installed on your computer
+# Define the path where the ChromeDriver executable is installed on your computer
 chrome_driver_path = r"C:\Users\ameli\Downloads\chromedriver-win64\chromedriver-win64\chromedriver.exe"
 
+# Define the path to the Chrome browser executable
 chrome_path = r'"C:\Program Files\Google\Chrome\Application\chrome.exe"'
 
 # Create an instance

--- a/chatgpt_selenium_automation/handler.py
+++ b/chatgpt_selenium_automation/handler.py
@@ -7,6 +7,7 @@ import logging
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.chrome.service import Service
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -73,10 +74,10 @@ class ChatGPTAutomation:
              with remote debugging enabled on the specified port"""
 
         chrome_options = webdriver.ChromeOptions()
-        chrome_options.binary_location = self.chrome_driver_path
+        chrome_options.binary_location = self.chrome_path
         chrome_options.add_experimental_option("debuggerAddress", f"127.0.0.1:{port}")
         try:
-            driver = webdriver.Chrome(options=chrome_options)
+            driver = webdriver.Chrome(service=Service(self.chrome_driver_path), options=chrome_options)
             logger.debug("WebDriver connected to Chrome on port %s", port)
             return driver
         except Exception as exc:


### PR DESCRIPTION
## Summary
- fix webdriver setup to point Chrome options at the Chrome binary
- pass chromedriver path via Service object
- clarify README example paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f849dc608328915fb3eb1254a9cc